### PR TITLE
 Allow arguments to be passed to exported function

### DIFF
--- a/highlight.py
+++ b/highlight.py
@@ -4,7 +4,7 @@ from pygments import styles
 from pygments.lexers import (get_lexer_by_name)
 
 
-def highlight_source_code():
+def highlight_source_code(*args):
     ctx = XSCRIPTCONTEXT
     doc = ctx.getDocument()
     highlight_all(doc)


### PR DESCRIPTION
Running this script on LibreOffice 4.3.7.2, I set the macro to be triggered on a Save Document action.

Macros triggered as events will pass com.sun.star.document.DocumentEvent objects to the script which will currently fail since highlight_source_code takes no arguments. This will just ignore all arguments passed in but at least it runs.
